### PR TITLE
Issues/118 Optimize StateEditor

### DIFF
--- a/Assets/Plugins/Unidux/Examples/Middlewares/Scripts/Unidux.cs
+++ b/Assets/Plugins/Unidux/Examples/Middlewares/Scripts/Unidux.cs
@@ -3,7 +3,7 @@ using UnityEngine;
 
 namespace Unidux.Example.Middlewares
 {
-    public class Unidux : SingletonMonoBehaviour<Unidux>
+    public class Unidux : SingletonMonoBehaviour<Unidux>, IStoreAccessor
     {
         public TextAsset InitialStateJson;
 

--- a/Assets/Plugins/Unidux/Examples/SceneTransition/Scripts/PageTitleRenderer.cs
+++ b/Assets/Plugins/Unidux/Examples/SceneTransition/Scripts/PageTitleRenderer.cs
@@ -19,7 +19,7 @@ namespace Unidux.Example.SceneTransition
 
         void Render(State state)
         {
-            this.GetComponent<Text>().text = state.Page.CurrentPage.ToString();
+            this.GetComponent<Text>().text = state.Page.Current.Page.ToString();
         }
     }
 }

--- a/Assets/Plugins/Unidux/Examples/SceneTransition/Scripts/PageWatcher.cs
+++ b/Assets/Plugins/Unidux/Examples/SceneTransition/Scripts/PageWatcher.cs
@@ -20,7 +20,7 @@ namespace Unidux.Example.SceneTransition
 
         void UpdateScene(State state)
         {
-            if (state.Scene.NeedsAdjust(config.GetPageScenes(), config.PageMap[state.Page.CurrentPage]))
+            if (state.Scene.NeedsAdjust(config.GetPageScenes(), config.PageMap[state.Page.Current.Page]))
             {
                 Unidux.Dispatch(PageDuck<Page, Scene>.ActionCreator.Adjust());
             }

--- a/Assets/Plugins/Unidux/Examples/SimpleHttp/Scripts/State.cs
+++ b/Assets/Plugins/Unidux/Examples/SimpleHttp/Scripts/State.cs
@@ -8,24 +8,5 @@ namespace Unidux.Example.SimpleHttp
         public string Url = "";
         public int StatusCode = -1;
         public string Body = "";
-
-        public override bool Equals(object obj)
-        {
-            if (obj is State)
-            {
-                var target = (State) obj;
-                return
-                    this.Url == target.Url &&
-                    this.StatusCode == target.StatusCode &&
-                    this.Body == target.Body;
-            }
-
-            return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
     }
 }

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
@@ -154,8 +154,9 @@ namespace Unidux.Experimental.Editor
                 EditorGUI.EndDisabledGroup();
             }
 
-            page = EditorGUILayout.IntField(pagerName, page);
-            EditorGUILayout.LabelField("/" + lastPage);
+            EditorGUILayout.LabelField(pagerName, GUILayout.MinWidth(30));
+            page = EditorGUILayout.IntField(page, GUILayout.MinWidth(30));
+            EditorGUILayout.LabelField("/" + lastPage, GUILayout.MinWidth(30));
 
             {
                 EditorGUI.BeginDisabledGroup(!hasNext);

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Reflection;
-using System.Text;
 using Unidux.Util;
 using UniRx;
 using UnityEditor;
@@ -11,8 +8,11 @@ using UnityEngine;
 
 namespace Unidux.Experimental.Editor
 {
-    public class UniduxPanelStateTab
+    public partial class UniduxPanelStateTab
     {
+        public delegate TResult Func6<in T1, in T2, in T3, in T4, in T5, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+            T5 arg5);
+
         private Vector2 _scrollPosition = Vector2.zero;
         private Dictionary<string, bool> _foldingMap = new Dictionary<string, bool>();
         private object _newState = null;
@@ -38,7 +38,7 @@ namespace Unidux.Experimental.Editor
                     this._newState = CloneUtil.MemoryClone(state);
                 }
 
-                var dirty = this.RenderObject(names, state.GetType().Name, type, this._newState, _ => { });
+                var dirty = this.RenderObject(names, state.GetType().Name, this._newState, type, _ => { });
                 EditorGUILayout.EndScrollView();
 
                 // XXX: it might be slow and should be updated less frequency.
@@ -50,60 +50,28 @@ namespace Unidux.Experimental.Editor
             }
         }
 
-        bool RenderObject(
-            List<string> rootNames,
-            string name,
-            Type type,
-            object element,
-            Action<object> setter
-        )
+        Func6<List<string>, string, object, Type, Action<object>, bool> SelectObjectRenderer(Type type, object element)
         {
-            bool dirty = false;
-
             // struct
             if (type.IsValueType)
             {
-                dirty |= this.RenderValue(rootNames, name, type, element, setter);
-            }
-            // non struct
-            else if (type == typeof(string))
-            {
-                var oldValue = (element as string);
-                var newValue = EditorGUILayout.TextField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is IDictionary)
-            {
-                rootNames.Add(name);
-
-                dirty |= RenderDictionary(rootNames, name, type, (IDictionary) element);
-
-                rootNames.RemoveLast();
-            }
-            else if (element is IList)
-            {
-                rootNames.Add(name);
-
-                dirty |= RenderList(rootNames, name, type, (IList) element);
-
-                rootNames.RemoveLast();
-            }
-            else if (!type.IsPrimitive)
-            {
-                rootNames.Add(name);
-
-                dirty |= RenderClass(rootNames, name, type, element);
-
-                rootNames.RemoveLast();
+                return this.SelectValueRender(type, element);
             }
             else
             {
-                Debug.LogWarning("UniduxPanel is unsupporting the Primitive Type: " + type);
+                return this.SelectClassRender(type, element);
             }
+        }
 
-            return dirty;
+        bool RenderObject(
+            List<string> rootNames,
+            string name,
+            object element,
+            Type type,
+            Action<object> setter
+        )
+        {
+            return this.SelectObjectRenderer(type, element)(rootNames, name, element, type, setter);
         }
 
         string GetFoldingName(ICollection<string> collection, string name)
@@ -114,332 +82,6 @@ namespace Unidux.Experimental.Editor
         string GetFoldingKey(IEnumerable<string> rootNames)
         {
             return string.Join(".", rootNames.ToArray());
-        }
-
-        bool RenderValue(
-            List<string> rootNames,
-            string name,
-            Type type,
-            object element,
-            Action<object> setter
-        )
-        {
-            bool dirty = false;
-
-            if (type == typeof(int?))
-            {
-                var oldValue = (int?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseInt();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is int)
-            {
-                var oldValue = (int) element;
-                var newValue = EditorGUILayout.IntField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (type == typeof(uint?))
-            {
-                var oldValue = (uint?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseUInt();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is uint)
-            {
-                var oldValue = (int) ((uint) element);
-                var newValue = EditorGUILayout.IntField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (newValue < 0) Debug.LogWarning("Illeagal uint value setted: " + newValue);
-                else if (dirty) setter((uint) newValue);
-            }
-            else if (type == typeof(float?))
-            {
-                var oldValue = (float?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseFloat();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is float)
-            {
-                var oldValue = (float) element;
-                var newValue = EditorGUILayout.FloatField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (type == typeof(double?))
-            {
-                var oldValue = (double?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseDouble();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is double)
-            {
-                var oldValue = (double) element;
-                var newValue = EditorGUILayout.DoubleField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (type == typeof(long?))
-            {
-                var oldValue = (long?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseLong();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is long)
-            {
-                var oldValue = (long) element;
-                var newValue = EditorGUILayout.LongField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (type == typeof(ulong?))
-            {
-                var oldValue = (ulong?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                var newValue = newValueString.ParseULong();
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is ulong)
-            {
-                var oldValue = (long) ((ulong) element);
-                var newValue = EditorGUILayout.LongField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (newValue < 0) Debug.LogWarning("Illeagal ulong value setted: " + newValue);
-                else if (dirty) setter((ulong) newValue);
-            }
-            else if (type == typeof(bool?))
-            {
-                var oldValue = (bool?) element;
-                var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
-                var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
-                bool? newValue = newValueString.ParseBool();
-
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is bool)
-            {
-                var oldValue = (bool) element;
-                var newValue = EditorGUILayout.Toggle(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (type.IsEnum)
-            {
-                string[] _choices = Enum.GetNames(type);
-                var oldValue = (int) element;
-                var newValue = EditorGUILayout.Popup(name, oldValue, _choices);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is Color)
-            {
-                var oldValue = (Color) element;
-                var newValue = EditorGUILayout.ColorField(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is Vector2)
-            {
-                var oldValue = (Vector2) element;
-                var newValue = EditorGUILayout.Vector2Field(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is Vector3)
-            {
-                var oldValue = (Vector3) element;
-                var newValue = EditorGUILayout.Vector3Field(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-            else if (element is Vector4)
-            {
-                var oldValue = (Vector4) element;
-                var newValue = EditorGUILayout.Vector4Field(name, oldValue);
-                dirty |= (oldValue != newValue);
-
-                if (dirty) setter(newValue);
-            }
-
-            return dirty;
-        }
-
-        bool RenderClass(List<string> rootNames, string name, Type type, object element)
-        {
-            bool dirty = false;
-            var foldingKey = this.GetFoldingKey(rootNames);
-
-            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
-                this._foldingMap.GetOrDefault(foldingKey, false),
-                this.GetFoldingName(rootNames, name)
-            );
-
-            if (this._foldingMap[foldingKey])
-            {
-                var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public);
-                var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
-
-                if (fields.Length <= 0 && properties.Length <= 0)
-                {
-                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" has no properties").ToString(),
-                        MessageType.Info);
-                }
-                else
-                {
-                    EditorGUILayout.BeginVertical(GUI.skin.box);
-
-                    foreach (var field in fields)
-                    {
-                        var value = field.GetValue(element);
-                        var valueType = field.FieldType;
-
-                        dirty |= RenderObject(
-                            rootNames,
-                            field.Name,
-                            valueType,
-                            value,
-                            newValue => field.SetValue(element, newValue));
-                    }
-
-                    foreach (var property in properties)
-                    {
-                        if (property.CanRead && property.CanWrite)
-                        {
-                            var value = property.GetValue(element, null);
-                            var valueType = property.PropertyType;
-
-                            dirty |= RenderObject(
-                                rootNames,
-                                property.Name,
-                                valueType,
-                                value,
-                                newValue => property.SetValue(element, newValue, null));
-                        }
-                    }
-
-                    EditorGUILayout.EndVertical();
-                }
-            }
-
-            return dirty;
-        }
-
-        bool RenderList(List<string> rootNames, string name, Type type, IList element)
-        {
-            bool dirty = false;
-            var index = 0;
-            var foldingKey = this.GetFoldingKey(rootNames);
-
-            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
-                this._foldingMap.GetOrDefault(foldingKey, false),
-                this.GetFoldingName(rootNames, name)
-            );
-
-            if (this._foldingMap[foldingKey])
-            {
-                if (element.Count <= 0)
-                {
-                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
-                }
-                else
-                {
-                    EditorGUILayout.BeginVertical(GUI.skin.box);
-
-                    var valueType = element[0].GetType();
-
-                    foreach (var e in element)
-                    {
-                        var arrayName = new StringBuilder(name).Append("[").Append(index).Append("]").ToString();
-                        dirty |= RenderObject(
-                            rootNames,
-                            arrayName,
-                            valueType,
-                            e,
-                            newValue => element[index] = newValue);
-                        index++;
-                    }
-                    EditorGUILayout.EndVertical();
-                }
-            }
-
-            return dirty;
-        }
-
-        bool RenderDictionary(List<string> rootNames, string name, Type type, IDictionary dictionary)
-        {
-            bool dirty = false;
-            var valueTypes = dictionary.Values.GetType().GetGenericArguments();
-            var valueType = valueTypes[1];
-            var foldingKey = this.GetFoldingKey(rootNames);
-
-            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
-                this._foldingMap.GetOrDefault(foldingKey, false),
-                name
-            );
-
-            if (this._foldingMap[foldingKey])
-            {
-                if (dictionary.Count <= 0)
-                {
-                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
-                }
-                else
-                {
-                    EditorGUILayout.BeginVertical(GUI.skin.box);
-                    IList keys = new ArrayList(dictionary.Keys);
-
-                    foreach (var key in keys)
-                    {
-                        dirty |= RenderObject(
-                            rootNames,
-                            key.ToString(),
-                            valueType,
-                            dictionary[key],
-                            newValue => dictionary[key] = newValue
-                        );
-                    }
-
-                    EditorGUILayout.EndVertical();
-                }
-            }
-
-            return dirty;
         }
     }
 }

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
@@ -32,13 +32,20 @@ namespace Unidux.Experimental.Editor
             // scrollview of state
             {
                 this._scrollPosition = EditorGUILayout.BeginScrollView(this._scrollPosition);
+
+                if (!(_store.StoreObject.ObjectState is ICloneable))
+                {
+                    EditorGUILayout.HelpBox("Please inplement ICloneable on State", MessageType.Warning);
+                    return;
+                }
+                
                 var state = _store.StoreObject.ObjectState;
                 var names = new List<string>();
                 var type = state.GetType();
 
                 if (!state.Equals(this._newState))
                 {
-                    this._newState = CloneUtil.MemoryClone(state);
+                    this._newState = ((ICloneable)state).Clone();
                 }
 
                 var dirty = this.RenderObject(names, state.GetType().Name, this._newState, type, _ => { });

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTab.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using Unidux.Example.Counter;
 using Unidux.Util;
 using UniRx;
 using UnityEditor;
@@ -10,13 +11,18 @@ namespace Unidux.Experimental.Editor
 {
     public partial class UniduxPanelStateTab
     {
-        public delegate TResult Func6<in T1, in T2, in T3, in T4, in T5, out TResult>(T1 arg1, T2 arg2, T3 arg3, T4 arg4,
+        public delegate TResult Func6<in T1, in T2, in T3, in T4, in T5, out TResult>(T1 arg1, T2 arg2, T3 arg3,
+            T4 arg4,
             T5 arg5);
 
         private Vector2 _scrollPosition = Vector2.zero;
         private Dictionary<string, bool> _foldingMap = new Dictionary<string, bool>();
+
+        private Dictionary<string, int> _pageMap = new Dictionary<string, int>();
+
         private object _newState = null;
         private ISubject<object> _stateSubject;
+        private const int PerPage = 100;
 
         public void Render(IStoreAccessor _store)
         {
@@ -72,6 +78,82 @@ namespace Unidux.Experimental.Editor
         )
         {
             return this.SelectObjectRenderer(type, element)(rootNames, name, element, type, setter);
+        }
+
+        int RenderPagerContent(
+            string foldingKey,
+            System.Collections.ICollection collection,
+            Action<object, int> renderValueWithIndex
+        )
+        {
+            var listSize = collection.Count;
+            var page = this._pageMap.GetOrDefault(foldingKey, 0);
+            var lastPage = (listSize - 1) / PerPage;
+            page = this.RenderPagerHeader(page, lastPage);
+            this._pageMap[foldingKey] = page;
+
+            var startIndex = page * PerPage;
+            var endIndex = Math.Min((page + 1) * PerPage, listSize);
+
+            var i = 0;
+            foreach (var element in collection)
+            {
+                if (i >= startIndex && i < endIndex)
+                {
+                    renderValueWithIndex(element, i);
+                }
+
+                i++;
+            }
+
+            return page;
+        }
+
+        int RenderPagerHeader(
+            int page,
+            int lastPage
+        )
+        {
+            bool hasPrev = page > 0;
+            bool hasNext = lastPage > page;
+
+            EditorGUILayout.BeginHorizontal();
+
+            {
+                EditorGUI.BeginDisabledGroup(!hasPrev);
+                if (GUILayout.Button("<<") && hasPrev)
+                {
+                    page -= 10;
+                }
+                if (GUILayout.Button("<") && hasPrev)
+                {
+                    page--;
+                }
+                EditorGUI.EndDisabledGroup();
+            }
+
+            page = EditorGUILayout.IntField("page", page);
+            EditorGUILayout.LabelField("/" + lastPage);
+
+            {
+                EditorGUI.BeginDisabledGroup(!hasNext);
+                if (GUILayout.Button(">") && hasNext)
+                {
+                    page++;
+                }
+                if (GUILayout.Button(">>") && hasNext)
+                {
+                    page += 10;
+                }
+                EditorGUI.EndDisabledGroup();
+            }
+
+            EditorGUILayout.EndHorizontal();
+
+            page = page < 0 ? 0 : page;
+            page = page > lastPage ? lastPage : page;
+
+            return page;
         }
 
         string GetFoldingName(ICollection<string> collection, string name)

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -51,6 +51,7 @@ namespace Unidux.Experimental.Editor
             rootNames.Add(name);
 
             bool dirty = false;
+            
             var foldingKey = this.GetFoldingKey(rootNames);
 
             this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
@@ -73,8 +74,10 @@ namespace Unidux.Experimental.Editor
                     if (fields.Length > 0)
                     {
                         EditorGUILayout.BeginVertical(GUI.skin.box);
+                        rootNames.Add("fields");
+                        var fieldFoldingKey = this.GetFoldingKey(rootNames);
 
-                        this.RenderPager("fields", foldingKey, fields, (_field, index) =>
+                        this.RenderPager("fields", fieldFoldingKey, fields, (_field, index) =>
                         {
                             var field = (FieldInfo) _field;
                             var value = field.GetValue(element);
@@ -87,15 +90,18 @@ namespace Unidux.Experimental.Editor
                                 valueType,
                                 newValue => field.SetValue(element, newValue));
                         });
-
+                        
+                        rootNames.RemoveLast();
                         EditorGUILayout.EndVertical();
                     }
 
                     if (properties.Length > 0)
                     {
                         EditorGUILayout.BeginVertical(GUI.skin.box);
+                        rootNames.Add("properties");
+                        var propertyFoldingKey = this.GetFoldingKey(rootNames);
 
-                        this.RenderPager("properties", foldingKey, properties, (_property, index) =>
+                        this.RenderPager("properties", propertyFoldingKey, properties, (_property, index) =>
                         {
                             var property = (PropertyInfo) _property;
 
@@ -117,6 +123,7 @@ namespace Unidux.Experimental.Editor
                             }
                         });
 
+                        rootNames.RemoveLast();
                         EditorGUILayout.EndVertical();
                     }
                 }

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -28,7 +28,7 @@ namespace Unidux.Experimental.Editor
             }
             else
             {
-                return RenderClass;
+                return this.RenderClass;
             }
         }
 
@@ -129,19 +129,24 @@ namespace Unidux.Experimental.Editor
                 else
                 {
                     EditorGUILayout.BeginVertical(GUI.skin.box);
+
                     IList keys = new ArrayList(dictionary.Keys);
                     var renderer = this.SelectObjectRenderer(valueType, dictionary[keys[0]]);
 
-                    foreach (var key in keys)
-                    {
-                        dirty |= renderer(
-                            rootNames,
-                            key.ToString(),
-                            dictionary[key],
-                            valueType,
-                            newValue => dictionary[key] = newValue
-                        );
-                    }
+                    this.RenderPagerContent(
+                        foldingKey,
+                        keys,
+                        (key, index) =>
+                        {
+                            dirty |= renderer(
+                                rootNames,
+                                key.ToString(),
+                                dictionary[key],
+                                valueType,
+                                newValue => dictionary[key] = newValue
+                            );
+                        }
+                    );
 
                     EditorGUILayout.EndVertical();
                 }
@@ -157,7 +162,6 @@ namespace Unidux.Experimental.Editor
 
             IList list = (IList) element;
             bool dirty = false;
-            var index = 0;
             var foldingKey = this.GetFoldingKey(rootNames);
 
             this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
@@ -178,18 +182,21 @@ namespace Unidux.Experimental.Editor
                     var valueType = list[0].GetType();
                     var render = this.SelectObjectRenderer(valueType, list[0]);
 
-                    foreach (var value in list)
-                    {
-                        var arrayName = new StringBuilder(name).Append("[").Append(index).Append("]").ToString();
-                        dirty |= render(
-                            rootNames,
-                            arrayName,
-                            value,
-                            valueType,
-                            newValue => list[index] = newValue);
-                        index++;
-                    }
-                    
+                    this.RenderPagerContent(
+                        foldingKey,
+                        list,
+                        (value, index) =>
+                        {
+                            var arrayName = new StringBuilder(name).Append("[").Append(index).Append("]").ToString();
+                            dirty |= render(
+                                rootNames,
+                                arrayName,
+                                value,
+                                valueType,
+                                newValue => list[index] = newValue);
+                        }
+                    );
+
                     EditorGUILayout.EndVertical();
                 }
             }

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -1,0 +1,201 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using Unidux.Util;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unidux.Experimental.Editor
+{
+    public partial class UniduxPanelStateTab
+    {
+        Func6<List<string>, string, object, Type, Action<object>, bool> SelectClassRender(Type type, object element)
+        {
+            // non struct
+            if (type == typeof(string))
+            {
+                return this.RenderString;
+            }
+            else if (element is IDictionary)
+            {
+                return this.RenderDictionary;
+            }
+            else if (element is IList)
+            {
+                return this.RenderList;
+            }
+            else
+            {
+                return RenderClass;
+            }
+        }
+
+        bool RenderString(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (element as string);
+            var newValue = EditorGUILayout.TextField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        bool RenderClass(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        {
+            rootNames.Add(name);
+
+            bool dirty = false;
+            var foldingKey = this.GetFoldingKey(rootNames);
+
+            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
+                this._foldingMap.GetOrDefault(foldingKey, false),
+                this.GetFoldingName(rootNames, name)
+            );
+
+            if (this._foldingMap[foldingKey])
+            {
+                var fields = type.GetFields(BindingFlags.Instance | BindingFlags.Public);
+                var properties = type.GetProperties(BindingFlags.Instance | BindingFlags.Public);
+
+                if (fields.Length <= 0 && properties.Length <= 0)
+                {
+                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" has no properties").ToString(),
+                        MessageType.Info);
+                }
+                else
+                {
+                    EditorGUILayout.BeginVertical(GUI.skin.box);
+
+                    foreach (var field in fields)
+                    {
+                        var value = field.GetValue(element);
+                        var valueType = field.FieldType;
+
+                        dirty |= RenderObject(
+                            rootNames,
+                            field.Name,
+                            value,
+                            valueType,
+                            newValue => field.SetValue(element, newValue));
+                    }
+
+                    foreach (var property in properties)
+                    {
+                        if (property.CanRead && property.CanWrite)
+                        {
+                            var value = property.GetValue(element, null);
+                            var valueType = property.PropertyType;
+
+                            dirty |= RenderObject(
+                                rootNames,
+                                property.Name,
+                                value,
+                                valueType,
+                                newValue => property.SetValue(element, newValue, null));
+                        }
+                    }
+
+                    EditorGUILayout.EndVertical();
+                }
+            }
+
+            rootNames.RemoveLast();
+            return dirty;
+        }
+
+        bool RenderDictionary(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        {
+            rootNames.Add(name);
+
+            IDictionary dictionary = (IDictionary) element;
+            bool dirty = false;
+            var valueTypes = dictionary.Values.GetType().GetGenericArguments();
+            var valueType = valueTypes[1];
+            var foldingKey = this.GetFoldingKey(rootNames);
+
+            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
+                this._foldingMap.GetOrDefault(foldingKey, false),
+                name
+            );
+
+            if (this._foldingMap[foldingKey])
+            {
+                if (dictionary.Count <= 0)
+                {
+                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
+                }
+                else
+                {
+                    EditorGUILayout.BeginVertical(GUI.skin.box);
+                    IList keys = new ArrayList(dictionary.Keys);
+                    var renderer = this.SelectObjectRenderer(valueType, dictionary[keys[0]]);
+
+                    foreach (var key in keys)
+                    {
+                        dirty |= renderer(
+                            rootNames,
+                            key.ToString(),
+                            dictionary[key],
+                            valueType,
+                            newValue => dictionary[key] = newValue
+                        );
+                    }
+
+                    EditorGUILayout.EndVertical();
+                }
+            }
+
+            rootNames.RemoveLast();
+            return dirty;
+        }
+
+        bool RenderList(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        {
+            rootNames.Add(name);
+
+            IList list = (IList) element;
+            bool dirty = false;
+            var index = 0;
+            var foldingKey = this.GetFoldingKey(rootNames);
+
+            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
+                this._foldingMap.GetOrDefault(foldingKey, false),
+                this.GetFoldingName(rootNames, name)
+            );
+
+            if (this._foldingMap[foldingKey])
+            {
+                if (list.Count <= 0)
+                {
+                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
+                }
+                else
+                {
+                    EditorGUILayout.BeginVertical(GUI.skin.box);
+
+                    var valueType = list[0].GetType();
+                    var render = this.SelectObjectRenderer(valueType, list[0]);
+
+                    foreach (var value in list)
+                    {
+                        var arrayName = new StringBuilder(name).Append("[").Append(index).Append("]").ToString();
+                        dirty |= render(
+                            rootNames,
+                            arrayName,
+                            value,
+                            valueType,
+                            newValue => list[index] = newValue);
+                        index++;
+                    }
+                    
+                    EditorGUILayout.EndVertical();
+                }
+            }
+
+            rootNames.RemoveLast();
+            return dirty;
+        }
+    }
+}

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -11,7 +11,7 @@ namespace Unidux.Experimental.Editor
 {
     public partial class UniduxPanelStateTab
     {
-        Func6<List<string>, string, object, Type, Action<object>, bool> SelectClassRender(Type type, object element)
+        Func6<IList<string>, string, object, Type, Action<object>, bool> SelectClassRender(Type type, object element)
         {
             // non struct
             if (type == typeof(string))
@@ -26,13 +26,17 @@ namespace Unidux.Experimental.Editor
             {
                 return this.RenderList;
             }
+            else if (element is ICollection)
+            {
+                return this.RenderCollection;
+            }
             else
             {
                 return this.RenderClass;
             }
         }
 
-        bool RenderString(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        bool RenderString(IList<string> rootNames, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (element as string);
             var newValue = EditorGUILayout.TextField(name, oldValue);
@@ -42,7 +46,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        bool RenderClass(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        bool RenderClass(IList<string> rootNames, string name, object element, Type type, Action<object> setter)
         {
             rootNames.Add(name);
 
@@ -105,7 +109,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        bool RenderDictionary(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        bool RenderDictionary(IList<string> rootNames, string name, object element, Type type, Action<object> setter)
         {
             rootNames.Add(name);
 
@@ -133,7 +137,7 @@ namespace Unidux.Experimental.Editor
                     IList keys = new ArrayList(dictionary.Keys);
                     var renderer = this.SelectObjectRenderer(valueType, dictionary[keys[0]]);
 
-                    this.RenderPagerContent(
+                    this.RenderPager(
                         foldingKey,
                         keys,
                         (key, index) =>
@@ -156,7 +160,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        bool RenderList(List<string> rootNames, string name, object element, Type type, Action<object> setter)
+        bool RenderList(IList<string> rootNames, string name, object element, Type type, Action<object> setter)
         {
             rootNames.Add(name);
 
@@ -182,7 +186,7 @@ namespace Unidux.Experimental.Editor
                     var valueType = list[0].GetType();
                     var render = this.SelectObjectRenderer(valueType, list[0]);
 
-                    this.RenderPagerContent(
+                    this.RenderPager(
                         foldingKey,
                         list,
                         (value, index) =>
@@ -195,6 +199,59 @@ namespace Unidux.Experimental.Editor
                                 valueType,
                                 newValue => list[index] = newValue);
                         }
+                    );
+
+                    EditorGUILayout.EndVertical();
+                }
+            }
+
+            rootNames.RemoveLast();
+            return dirty;
+        }
+
+        bool RenderCollection(IList<string> rootNames, string name, object element, Type type, Action<object> setter)
+        {
+            rootNames.Add(name);
+
+            ICollection list = (ICollection) element;
+            bool dirty = false;
+            var foldingKey = this.GetFoldingKey(rootNames);
+
+            this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
+                this._foldingMap.GetOrDefault(foldingKey, false),
+                this.GetFoldingName(rootNames, name)
+            );
+
+            if (this._foldingMap[foldingKey])
+            {
+                if (list.Count <= 0)
+                {
+                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
+                }
+                else
+                {
+                    EditorGUILayout.BeginVertical(GUI.skin.box);
+
+                    var enumerator = list.GetEnumerator();
+                    enumerator.MoveNext();
+                    var _firstValue = enumerator.Current;
+                    var valueType = _firstValue.GetType();
+                    var render = this.SelectObjectRenderer(valueType, _firstValue);
+
+                    this.RenderPager(
+                        foldingKey,
+                        list,
+                        (value, index) =>
+                        {
+                            var arrayName = new StringBuilder(name).Append("[").Append(index).Append("]").ToString();
+                            dirty |= render(
+                                rootNames,
+                                arrayName,
+                                value,
+                                valueType,
+                                newValue => { });
+                        },
+                        true
                     );
 
                     EditorGUILayout.EndVertical();

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -65,43 +65,60 @@ namespace Unidux.Experimental.Editor
 
                 if (fields.Length <= 0 && properties.Length <= 0)
                 {
-                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" has no properties").ToString(),
+                    EditorGUILayout.HelpBox(new StringBuilder(name).Append(" has no properties or fields").ToString(),
                         MessageType.Info);
                 }
                 else
                 {
-                    EditorGUILayout.BeginVertical(GUI.skin.box);
-                    
-                    foreach (var field in fields)
+                    if (fields.Length > 0)
                     {
-                        var value = field.GetValue(element);
-                        var valueType = field.FieldType;
+                        EditorGUILayout.BeginVertical(GUI.skin.box);
 
-                        dirty |= RenderObject(
-                            rootNames,
-                            field.Name,
-                            value,
-                            valueType,
-                            newValue => field.SetValue(element, newValue));
-                    }
-
-                    foreach (var property in properties)
-                    {
-                        if (property.CanRead && property.CanWrite)
+                        this.RenderPager("fields", foldingKey, fields, (_field, index) =>
                         {
-                            var value = property.GetValue(element, null);
-                            var valueType = property.PropertyType;
+                            var field = (FieldInfo) _field;
+                            var value = field.GetValue(element);
+                            var valueType = field.FieldType;
 
                             dirty |= RenderObject(
                                 rootNames,
-                                property.Name,
+                                field.Name,
                                 value,
                                 valueType,
-                                newValue => property.SetValue(element, newValue, null));
-                        }
+                                newValue => field.SetValue(element, newValue));
+                        });
+
+                        EditorGUILayout.EndVertical();
                     }
 
-                    EditorGUILayout.EndVertical();
+                    if (properties.Length > 0)
+                    {
+                        EditorGUILayout.BeginVertical(GUI.skin.box);
+
+                        this.RenderPager("properties", foldingKey, properties, (_property, index) =>
+                        {
+                            var property = (PropertyInfo) _property;
+
+                            if (element != null)
+                            {
+                                var value = property.GetValue(element, null);
+                                var valueType = property.PropertyType;
+
+                                dirty |= RenderObject(
+                                    rootNames,
+                                    property.Name,
+                                    value,
+                                    valueType,
+                                    newValue => property.SetValue(element, newValue, null));
+                            }
+                            else
+                            {
+                                EditorGUILayout.LabelField("null");
+                            }
+                        });
+
+                        EditorGUILayout.EndVertical();
+                    }
                 }
             }
 

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -51,7 +51,7 @@ namespace Unidux.Experimental.Editor
             rootNames.Add(name);
 
             bool dirty = false;
-            
+
             var foldingKey = this.GetFoldingKey(rootNames);
 
             this._foldingMap[foldingKey] = EditorGUILayout.Foldout(
@@ -81,7 +81,7 @@ namespace Unidux.Experimental.Editor
                         {
                             var field = (FieldInfo) _field;
                             var value = field.GetValue(element);
-                            var valueType = field.FieldType;
+                            var valueType = (value != null) ? value.GetType() : field.FieldType;
 
                             dirty |= RenderObject(
                                 rootNames,
@@ -90,7 +90,7 @@ namespace Unidux.Experimental.Editor
                                 valueType,
                                 newValue => field.SetValue(element, newValue));
                         });
-                        
+
                         rootNames.RemoveLast();
                         EditorGUILayout.EndVertical();
                     }
@@ -99,6 +99,7 @@ namespace Unidux.Experimental.Editor
                     {
                         EditorGUILayout.BeginVertical(GUI.skin.box);
                         rootNames.Add("properties");
+
                         var propertyFoldingKey = this.GetFoldingKey(rootNames);
 
                         this.RenderPager("properties", propertyFoldingKey, properties, (_property, index) =>
@@ -108,14 +109,30 @@ namespace Unidux.Experimental.Editor
                             if (element != null)
                             {
                                 var value = property.GetValue(element, null);
-                                var valueType = property.PropertyType;
+                                var valueType = (value != null) ? value.GetType() : property.PropertyType;
+
+                                if (!property.CanWrite)
+                                {
+                                    EditorGUI.BeginDisabledGroup(true);
+                                }
 
                                 dirty |= RenderObject(
                                     rootNames,
                                     property.Name,
                                     value,
                                     valueType,
-                                    newValue => property.SetValue(element, newValue, null));
+                                    newValue =>
+                                    {
+                                        if (property.CanWrite)
+                                        {
+                                            property.SetValue(element, newValue, null);
+                                        }
+                                    });
+
+                                if (!property.CanWrite)
+                                {
+                                    EditorGUI.EndDisabledGroup();
+                                }
                             }
                             else
                             {

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs
@@ -71,7 +71,7 @@ namespace Unidux.Experimental.Editor
                 else
                 {
                     EditorGUILayout.BeginVertical(GUI.skin.box);
-
+                    
                     foreach (var field in fields)
                     {
                         var value = field.GetValue(element);
@@ -138,6 +138,7 @@ namespace Unidux.Experimental.Editor
                     var renderer = this.SelectObjectRenderer(valueType, dictionary[keys[0]]);
 
                     this.RenderPager(
+                        "dictionary",
                         foldingKey,
                         keys,
                         (key, index) =>
@@ -187,6 +188,7 @@ namespace Unidux.Experimental.Editor
                     var render = this.SelectObjectRenderer(valueType, list[0]);
 
                     this.RenderPager(
+                        "list",
                         foldingKey,
                         list,
                         (value, index) =>
@@ -239,6 +241,7 @@ namespace Unidux.Experimental.Editor
                     var render = this.SelectObjectRenderer(valueType, _firstValue);
 
                     this.RenderPager(
+                        "collection",
                         foldingKey,
                         list,
                         (value, index) =>

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs.meta
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabClassRender.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 617dddc7a1783439fb5d5d3b13895b39
+timeCreated: 1509171272

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
@@ -1,0 +1,310 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Unidux.Util;
+using UnityEditor;
+using UnityEngine;
+
+namespace Unidux.Experimental.Editor
+{
+    public partial class UniduxPanelStateTab
+    {
+        protected Func6<List<string>, string, object, Type, Action<object>, bool> SelectValueRender(Type type, object element)
+        {
+            if (type == typeof(int?))
+            {
+                return this.RenderUInt;
+            }
+            else if (element is int)
+            {
+                return this.RenderInt;
+            }
+            else if (type == typeof(uint?))
+            {
+                return this.RenderNullabelUInt;
+            }
+            else if (element is uint)
+            {
+                return this.RenderUInt;
+            }
+            else if (type == typeof(float?))
+            {
+                return this.RenderNullableFloat;
+            }
+            else if (element is float)
+            {
+                return this.RenderFloat;
+            }
+            else if (type == typeof(double?))
+            {
+                return this.RenderNullableDouble;
+            }
+            else if (element is double)
+            {
+                return this.RenderDouble;
+            }
+            else if (type == typeof(long?))
+            {
+                return this.RenderNullableLong;
+            }
+            else if (element is long)
+            {
+                return this.RenderLong;
+            }
+            else if (type == typeof(ulong?))
+            {
+                return this.RenderNullableULong;
+            }
+            else if (element is ulong)
+            {
+                return this.RenderULong;
+            }
+            else if (type == typeof(bool?))
+            {
+                return this.RenderNullableBool;
+            }
+            else if (element is bool)
+            {
+                return this.RenderBool;
+            }
+            else if (type.IsEnum)
+            {
+                return this.RenderEnum;
+            }
+            else if (element is Color)
+            {
+                return this.RenderColor;
+            }
+            else if (element is Vector2)
+            {
+                return this.RenderVector2;
+            }
+            else if (element is Vector3)
+            {
+                return this.RenderVector3;
+            }
+            else if (element is Vector4)
+            {
+                return this.RenderVector4;
+            }
+
+            return this.RenderUnknown;
+        }
+
+        protected bool RenderUnknown(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
+            return false;
+        }
+
+        protected bool RenderNullableInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (int?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseInt();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+
+            return dirty;
+        }
+
+        protected bool RenderInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (int) element;
+            var newValue = EditorGUILayout.DelayedIntField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderNullabelUInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (uint?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseUInt();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderUInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (int) ((uint) element);
+            var newValue = EditorGUILayout.DelayedIntField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (newValue < 0) Debug.LogWarning("Illeagal uint value setted: " + newValue);
+            else if (dirty) setter((uint) newValue);
+
+            return dirty;
+        }
+
+        protected bool RenderNullableFloat(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (float?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseFloat();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderFloat(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (float) element;
+            var newValue = EditorGUILayout.DelayedFloatField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderNullableDouble(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (double?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseDouble();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderDouble(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (float) element;
+            var newValue = EditorGUILayout.DelayedDoubleField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderNullableLong(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (long?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseLong();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderLong(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (long) element;
+            var newValue = EditorGUILayout.LongField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderNullableULong(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (ulong?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            var newValue = newValueString.ParseULong();
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderULong(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (long) ((ulong) element);
+            var newValue = EditorGUILayout.LongField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (newValue < 0) Debug.LogWarning("Illeagal ulong value setted: " + newValue);
+            else if (dirty) setter((ulong) newValue);
+            return dirty;
+        }
+
+        protected bool RenderNullableBool(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (bool?) element;
+            var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
+            var newValueString = EditorGUILayout.DelayedTextField(name, oldValueString);
+            bool? newValue = newValueString.ParseBool();
+
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderBool(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (bool) element;
+            var newValue = EditorGUILayout.Toggle(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderEnum(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            string[] _choices = Enum.GetNames(type);
+            var oldValue = (int) element;
+            var newValue = EditorGUILayout.Popup(name, oldValue, _choices);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderColor(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (Color) element;
+            var newValue = EditorGUILayout.ColorField(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderVector2(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (Vector2) element;
+            var newValue = EditorGUILayout.Vector2Field(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderVector3(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (Vector3) element;
+            var newValue = EditorGUILayout.Vector3Field(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+
+        protected bool RenderVector4(List<string> _, string name, object element, Type type, Action<object> setter)
+        {
+            var oldValue = (Vector4) element;
+            var newValue = EditorGUILayout.Vector4Field(name, oldValue);
+            var dirty = (oldValue != newValue);
+
+            if (dirty) setter(newValue);
+            return dirty;
+        }
+    }
+}

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
@@ -9,11 +9,11 @@ namespace Unidux.Experimental.Editor
 {
     public partial class UniduxPanelStateTab
     {
-        protected Func6<List<string>, string, object, Type, Action<object>, bool> SelectValueRender(Type type, object element)
+        protected Func6<IList<string>, string, object, Type, Action<object>, bool> SelectValueRender(Type type, object element)
         {
             if (type == typeof(int?))
             {
-                return this.RenderUInt;
+                return this.RenderNullableInt;
             }
             else if (element is int)
             {
@@ -91,13 +91,13 @@ namespace Unidux.Experimental.Editor
             return this.RenderUnknown;
         }
 
-        protected bool RenderUnknown(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderUnknown(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             EditorGUILayout.HelpBox(new StringBuilder(name).Append(" is empty").ToString(), MessageType.Info);
             return false;
         }
 
-        protected bool RenderNullableInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableInt(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (int?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -110,7 +110,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderInt(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (int) element;
             var newValue = EditorGUILayout.DelayedIntField(name, oldValue);
@@ -120,7 +120,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullabelUInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullabelUInt(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (uint?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -132,7 +132,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderUInt(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderUInt(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (int) ((uint) element);
             var newValue = EditorGUILayout.DelayedIntField(name, oldValue);
@@ -144,7 +144,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullableFloat(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableFloat(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (float?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -156,7 +156,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderFloat(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderFloat(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (float) element;
             var newValue = EditorGUILayout.DelayedFloatField(name, oldValue);
@@ -166,7 +166,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullableDouble(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableDouble(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (double?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -178,7 +178,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderDouble(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderDouble(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (float) element;
             var newValue = EditorGUILayout.DelayedDoubleField(name, oldValue);
@@ -188,7 +188,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullableLong(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableLong(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (long?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -200,7 +200,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderLong(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderLong(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (long) element;
             var newValue = EditorGUILayout.LongField(name, oldValue);
@@ -210,7 +210,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullableULong(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableULong(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (ulong?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -222,7 +222,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderULong(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderULong(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (long) ((ulong) element);
             var newValue = EditorGUILayout.LongField(name, oldValue);
@@ -233,7 +233,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderNullableBool(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderNullableBool(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (bool?) element;
             var oldValueString = oldValue.HasValue ? oldValue.Value.ToString() : "null";
@@ -246,7 +246,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderBool(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderBool(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (bool) element;
             var newValue = EditorGUILayout.Toggle(name, oldValue);
@@ -256,7 +256,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderEnum(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderEnum(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             string[] _choices = Enum.GetNames(type);
             var oldValue = (int) element;
@@ -267,7 +267,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderColor(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderColor(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (Color) element;
             var newValue = EditorGUILayout.ColorField(name, oldValue);
@@ -277,7 +277,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderVector2(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderVector2(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (Vector2) element;
             var newValue = EditorGUILayout.Vector2Field(name, oldValue);
@@ -287,7 +287,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderVector3(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderVector3(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (Vector3) element;
             var newValue = EditorGUILayout.Vector3Field(name, oldValue);
@@ -297,7 +297,7 @@ namespace Unidux.Experimental.Editor
             return dirty;
         }
 
-        protected bool RenderVector4(List<string> _, string name, object element, Type type, Action<object> setter)
+        protected bool RenderVector4(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
             var oldValue = (Vector4) element;
             var newValue = EditorGUILayout.Vector4Field(name, oldValue);

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs
@@ -180,7 +180,7 @@ namespace Unidux.Experimental.Editor
 
         protected bool RenderDouble(IList<string> _, string name, object element, Type type, Action<object> setter)
         {
-            var oldValue = (float) element;
+            var oldValue = (double) element;
             var newValue = EditorGUILayout.DelayedDoubleField(name, oldValue);
             var dirty = (oldValue != newValue);
 

--- a/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs.meta
+++ b/Assets/Plugins/Unidux/Scripts/Experimental/Editor/UniduxPanelStateTabValueRender.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 3298f75017304f87b0f1bc49c35abb0c
+timeCreated: 1509171272

--- a/Assets/Plugins/Unidux/Scripts/SceneTransition/PageDuck.cs
+++ b/Assets/Plugins/Unidux/Scripts/SceneTransition/PageDuck.cs
@@ -144,7 +144,7 @@ namespace Unidux.SceneTransition
                     return pageState;
                 }
 
-                if (pageState.Stack.Any() && pageState.CurrentPage.Equals(action.Page))
+                if (pageState.Stack.Any() && pageState.Current.Page.Equals(action.Page))
                 {
                     Debug.LogWarning(
                         "Page pushing failed. Cannot push same page at once: " + action.Page);
@@ -219,7 +219,7 @@ namespace Unidux.SceneTransition
 
                 if (pageState.Stack.Any())
                 {
-                    var page = pageState.CurrentPage;
+                    var page = pageState.Current.Page;
 
                     if (!config.PageMap.ContainsKey(page))
                     {

--- a/Assets/Plugins/Unidux/Scripts/SceneTransition/PageState.cs
+++ b/Assets/Plugins/Unidux/Scripts/SceneTransition/PageState.cs
@@ -7,27 +7,27 @@ namespace Unidux.SceneTransition
     [Serializable]
     public class PageState<TPage> : StateElement, ICloneable where TPage : struct
     {
-        // XXX: System.Collections.Generic.Stack is not visible on UniduxEditorStateTab, because it's not writable on dynamically. So use IList instead of Stack now,
+        // TODO: change typw from IList to Stack 
         public readonly IList<IPageEntity<TPage>> Stack = new List<IPageEntity<TPage>>();
 
         public IPageEntity<TPage> Current
         {
-            get { return this.Stack.Last(); }
+            get { return this.Stack.Count > 0 ? this.Stack.Last() : null; }
         }
 
-        public TPage CurrentPage
+        public string Name
         {
-            get { return this.Current.Page; }
+            get { return this.Stack.Count > 0 ? this.Current.Page.ToString() : "-"; }
         }
 
-        public IPageData CurrentData
+        public IPageData Data
         {
-            get { return this.Current.Data; }
+            get { return this.Current != null ? this.Current.Data : null; }
         }
 
-        public TData GetCurrentData<TData>() where TData : IPageData
+        public TData GetData<TData>() where TData : IPageData
         {
-            return (TData) this.CurrentData;
+            return (TData) this.Current.Data;
         }
 
         public bool IsReady
@@ -41,31 +41,17 @@ namespace Unidux.SceneTransition
 
         public PageState(PageState<TPage> state)
         {
-            foreach(var page in state.Stack)
+            foreach (var page in state.Stack)
             {
                 this.Stack.Add(page);
             }
+
+            this.SetStateChanged(state.IsStateChanged);
         }
 
         public object Clone()
         {
             return new PageState<TPage>(this);
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj is PageState<TPage>)
-            {
-                var target = (PageState<TPage>) obj;
-                return this.Stack.SequenceEqual(target.Stack);
-            }
-
-            return false;
-        }
-
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
         }
     }
 }

--- a/Assets/Plugins/Unidux/Test/Editor/SceneTransition/PageDuckTest.cs
+++ b/Assets/Plugins/Unidux/Test/Editor/SceneTransition/PageDuckTest.cs
@@ -29,8 +29,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page1, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page1, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -47,8 +47,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page1, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page1, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -64,8 +64,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page2, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page2, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(2, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -96,8 +96,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page1, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page1, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -114,8 +114,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page1, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page1, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -135,8 +135,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page1, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page1, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -153,8 +153,8 @@ namespace Unidux.SceneTransition
                 );
 
                 Assert.IsTrue(result.IsReady);
-                Assert.AreEqual(SamplePage.Page2, result.CurrentPage);
-                Assert.IsNull(result.CurrentData);
+                Assert.AreEqual(SamplePage.Page2, result.Current.Page);
+                Assert.IsNull(result.Current.Data);
                 Assert.AreEqual(1, result.Stack.Count);
 
                 Assert.AreEqual(2, sceneState.ActiveMap.Count);
@@ -230,7 +230,7 @@ namespace Unidux.SceneTransition
             {
                 Assert.IsTrue(pageState.IsReady);
                 Assert.AreEqual(1, pageState.Stack.Count);
-                Assert.AreNotEqual(new SamplePageData(2), pageState.CurrentData);
+                Assert.AreNotEqual(new SamplePageData(2), pageState.Current.Data);
 
                 var result = reducer.Reduce(
                     pageState,
@@ -239,7 +239,7 @@ namespace Unidux.SceneTransition
                 );
                 Assert.IsTrue(result.IsReady);
                 Assert.AreEqual(1, result.Stack.Count);
-                Assert.AreEqual(new SamplePageData(2), result.CurrentData);
+                Assert.AreEqual(new SamplePageData(2), result.Current.Data);
             }
         }
 


### PR DESCRIPTION
## ISSUE

- #118 

## TODO

- [x] Divide StateTab render
- [x] Support Pager
- [x] Support ICollection
- [x] Optimize IList/IDictionary display
- [x] Fix display of SceneTransition example
- [x] Disable when property is not writable
- [x] Change clone method to refer `State.Clone()`

<img width="464" alt="2017-10-30 1 29 30 am" src="https://user-images.githubusercontent.com/522828/32145824-ef6963b8-bd11-11e7-9cff-491183c79efd.png">
<img width="462" alt="2017-10-30 1 30 03 am" src="https://user-images.githubusercontent.com/522828/32145825-ef8d622c-bd11-11e7-81db-1b7c6041aecd.png">

